### PR TITLE
JOB-56238 Force SSL for rails api template in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,7 +41,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).


### PR DESCRIPTION
# What's in this PR?

- Why was this PR created?
Force the app to have a secure connection over SSL.

- Quick summary of the changes you made.
Added `config.foce_ssl = true` to `config/environments/production.rb` 

## Before

App did not enforce SSL connection.

## After

App forces an SSL connection.

# QA

- [x] This has been QA'd by the PR owner
- [x] This has been QA'd by an approver

# References

[Securing Rails Applications - Ruby on Rails Guides](https://guides.rubyonrails.org/security.html#session-hijacking)